### PR TITLE
Fixing a couple of compilation issues

### DIFF
--- a/MSVC12/algo_test/algo_test.vcxproj
+++ b/MSVC12/algo_test/algo_test.vcxproj
@@ -168,6 +168,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/MSVC12/openfstwinlib/OpenfstWinLib.vcxproj
+++ b/MSVC12/openfstwinlib/OpenfstWinLib.vcxproj
@@ -169,6 +169,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>openfst.def</ModuleDefinitionFile>

--- a/src/include/fst/generic-register.h
+++ b/src/include/fst/generic-register.h
@@ -76,7 +76,7 @@ class GenericRegister {
   virtual EntryType LoadEntryFromSharedObject(const KeyType &key) const {
 #ifdef FST_NO_DYNAMIC_LINKING
     return EntryType();
-#elif //Added PD
+#else //Added PD
     string so_filename = ConvertKeyToSoFilename(key);
     void *handle = dlopen(so_filename.c_str(), RTLD_LAZY);
     if (handle == 0) {


### PR DESCRIPTION
/bigobj is needed for the library and algo_test to compile in debug both in MSVC2013 and MSVC2015rc
Fxiing #elif to #else -- the MSVC2015 didn't like it.
